### PR TITLE
fix: round-trip properly serde_json::Value

### DIFF
--- a/src/de.rs
+++ b/src/de.rs
@@ -1,4 +1,4 @@
-use js_sys::{Array, ArrayBuffer, JsString, Number, Object, Uint8Array};
+use js_sys::{Array, ArrayBuffer, JsString, Map, Number, Object, Symbol, Uint8Array};
 use serde::de::value::{MapDeserializer, SeqDeserializer};
 use serde::de::{self, IntoDeserializer};
 use std::convert::TryFrom;
@@ -314,7 +314,22 @@ impl<'de> de::Deserializer<'de> for Deserializer {
             // We need to handle this here because serde uses `deserialize_any`
             // for internally tagged enums
             visitor.visit_byte_buf(bytes)
-        } else if self.value.is_object() {
+        } else if self.value.is_object() &&
+            // The only reason we want to support objects here is because serde uses
+            // `deserialize_any` for internally tagged enums
+            // (see https://github.com/RReverser/serde-wasm-bindgen/pull/4#discussion_r352245020).
+            //
+            // We expect such enums to be represented via plain JS objects, so let's explicitly
+            // exclude Sets and other iterables. These should be deserialized via concrete
+            // `deserialize_*` methods instead of us trying to guess the right target type.
+            //
+            // We still do support Map, so that the format described here stays a self-describing
+            // format: we happen to serialize to Map, and it is not ambiguous.
+            //
+            // Hopefully we can rid of these hacks altogether once
+            // https://github.com/serde-rs/serde/issues/1183 is implemented / fixed on serde side.
+            (!Symbol::iterator().js_in(&self.value) || self.value.has_type::<Map>())
+        {
             self.deserialize_map(visitor)
         } else {
             self.invalid_type(visitor)

--- a/src/de.rs
+++ b/src/de.rs
@@ -1,4 +1,4 @@
-use js_sys::{Array, ArrayBuffer, JsString, Number, Object, Symbol, Uint8Array};
+use js_sys::{Array, ArrayBuffer, JsString, Number, Object, Uint8Array};
 use serde::de::value::{MapDeserializer, SeqDeserializer};
 use serde::de::{self, IntoDeserializer};
 use std::convert::TryFrom;
@@ -314,19 +314,7 @@ impl<'de> de::Deserializer<'de> for Deserializer {
             // We need to handle this here because serde uses `deserialize_any`
             // for internally tagged enums
             visitor.visit_byte_buf(bytes)
-        } else if self.value.is_object() &&
-            // The only reason we want to support objects here is because serde uses
-            // `deserialize_any` for internally tagged enums
-            // (see https://github.com/RReverser/serde-wasm-bindgen/pull/4#discussion_r352245020).
-            //
-            // We expect such enums to be represented via plain JS objects, so let's explicitly
-            // exclude Sets, Maps and any other iterables. These should be deserialized via concrete
-            // `deserialize_*` methods instead of us trying to guess the right target type.
-            //
-            // Hopefully we can rid of these hacks altogether once
-            // https://github.com/serde-rs/serde/issues/1183 is implemented / fixed on serde side.
-            !Symbol::iterator().js_in(&self.value)
-        {
+        } else if self.value.is_object() {
             self.deserialize_map(visitor)
         } else {
             self.invalid_type(visitor)

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -13,6 +13,8 @@ use wasm_bindgen_test::wasm_bindgen_test;
 
 const SERIALIZER: Serializer = Serializer::new();
 
+const JSON_SERIALIZER: Serializer = Serializer::json_compatible();
+
 const BIGINT_SERIALIZER: Serializer =
     Serializer::new().serialize_large_number_types_as_bigints(true);
 
@@ -665,7 +667,19 @@ fn enums() {
 }
 
 #[wasm_bindgen_test]
-fn serde_json_value() {
+fn serde_json_value_with_json() {
+    test_via_round_trip_with_config(
+        serde_json::from_str::<serde_json::Value>("[0, \"foo\"]").unwrap(),
+        &JSON_SERIALIZER,
+    );
+    test_via_round_trip_with_config(
+        serde_json::from_str::<serde_json::Value>(r#"{"foo": "bar"}"#).unwrap(),
+        &JSON_SERIALIZER,
+    );
+}
+
+#[wasm_bindgen_test]
+fn serde_json_value_with_default() {
     test_via_round_trip_with_config(
         serde_json::from_str::<serde_json::Value>("[0, \"foo\"]").unwrap(),
         &SERIALIZER,

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -665,6 +665,18 @@ fn enums() {
 }
 
 #[wasm_bindgen_test]
+fn serde_json_value() {
+    test_via_round_trip_with_config(
+        serde_json::from_str::<serde_json::Value>("[0, \"foo\"]").unwrap(),
+        &SERIALIZER,
+    );
+    test_via_round_trip_with_config(
+        serde_json::from_str::<serde_json::Value>(r#"{"foo": "bar"}"#).unwrap(),
+        &SERIALIZER,
+    );
+}
+
+#[wasm_bindgen_test]
 fn preserved_value() {
     #[derive(serde::Deserialize, serde::Serialize, PartialEq, Clone, Debug)]
     #[serde(bound = "T: JsCast")]


### PR DESCRIPTION
The case that led to me looking into this, is trying to round-trip through serde_wasm_bindgen a serde_json::Value that is a simple map.

I also added a test for round-tripping an array, but it looks like that test just passed without any changes.